### PR TITLE
group might be null during some time

### DIFF
--- a/src/XamEffects.Droid/TouchEffectPlatform.cs
+++ b/src/XamEffects.Droid/TouchEffectPlatform.cs
@@ -244,8 +244,11 @@ namespace XamEffects.Droid {
 
         private void ViewOnLayoutChange(object sender, View.LayoutChangeEventArgs layoutChangeEventArgs) {
             var group = ((ViewGroup)sender);
-            _viewOverlay.Right = group.Width;
-            _viewOverlay.Bottom = group.Height;
+            if (group != null)
+            {   
+                _viewOverlay.Right = group.Width;
+                _viewOverlay.Bottom = group.Height;
+            }
         }
     }
 }


### PR DESCRIPTION
(after detached, or at page change)
ex: 
02-04 13:28:14.105 I/MonoDroid( 9743): System.ObjectDisposedException: Cannot access a disposed object.
02-04 13:28:14.105 I/MonoDroid( 9743): Object name: 'Android.Widget.FrameLayout'.
02-04 13:28:14.105 I/MonoDroid( 9743):   at Java.Interop.JniPeerMembers.AssertSelf (Java.Interop.IJavaPeerable self) [0x00029] in <8acc8089c2ed40d08469fbaa6710a44c>:0 
02-04 13:28:14.105 I/MonoDroid( 9743):   at Java.Interop.JniPeerMembers+JniInstanceMethods.InvokeNonvirtualVoidMethod (System.String encodedMember, Java.Interop.IJavaPeerable self, Java.Interop.JniArgumentValue* parameters) [0x00000] in <8acc8089c2ed40d08469fbaa6710a44c>:0 
02-04 13:28:14.105 I/MonoDroid( 9743):   at Android.Views.View.set_Right (System.Int32 value) [0x00022] in <6f8818d6ffa14f4bad6fb5f5d0f0e665>:0 
02-04 13:28:14.105 I/MonoDroid( 9743):   at XamEffects.Droid.TouchEffectPlatform.ViewOnLayoutChange (System.Object sender, Android.Views.View+LayoutChangeEventArgs layoutChangeEventArgs) [0x00007] in /Users/XXXXX/Documents/Projects/XamEffects/src/XamEffects.Droid/TouchEffectPlatform.cs:247 
02-04 13:28:14.105 I/MonoDroid( 9743):   at (wrapper delegate-invoke) System.EventHandler`1[Android.Views.View+LayoutChangeEventArgs].invoke_void_object_TEventArgs(object,Android.Views.View/LayoutChangeEventArgs)
02-04 13:28:14.105 I/MonoDroid( 9743):   at Android.Views.View+IOnLayoutChangeListenerImplementor.OnLayoutChange (Android.Views.View v, System.Int32 left, System.Int32 top, System.Int32 right, System.Int32 bottom, System.Int32 oldLeft, System.Int32 oldTop, System.Int32 oldRight, System.Int32 oldBottom) [0x0001f] in <6f8818d6ffa14f4bad6fb5f5d0f0e665>:0 
02-04 13:28:14.105 I/MonoDroid( 9743):   at Android.Views.View+IOnLayoutChangeListenerInvoker.n_OnLayoutChange_Landroid_view_View_IIIIIIII (System.IntPtr jnienv, System.IntPtr native__this, System.IntPtr native_v, System.Int32 left, System.Int32 top, System.Int32 right, System.Int32 bottom, System.Int32 oldLeft, System.Int32 oldTop, System.Int32 oldRight, System.Int32 oldBottom) [0x00011] in <6f8818d6ffa14f4bad6fb5f5d0f0e665>:0 
02-04 13:28:14.105 I/MonoDroid( 9743):   at (wrapper dynamic-method) System.Object.98(intptr,intptr,intptr,int,int,int,int,int,int,int,int)
02-04 13:28:14.135 W/zygote  ( 9743): JNI RegisterNativeMethods: attempt to register 0 native methods for android.runtime.JavaProxyThrowable