### PR TITLE
Adding TalkBack accessibility to touchEffect

### DIFF
--- a/src/XamEffects.Droid/TouchEffectPlatform.cs
+++ b/src/XamEffects.Droid/TouchEffectPlatform.cs
@@ -47,6 +47,15 @@ namespace XamEffects.Droid {
                 Clickable = false,
                 Focusable = false,
             };
+
+            bool? isInAccessibleTree = (bool?)Element.GetValue(AutomationProperties.IsInAccessibleTreeProperty);
+            if (isInAccessibleTree.HasValue && isInAccessibleTree.Value)
+            {
+                _viewOverlay.Focusable = isInAccessibleTree ?? Control.Focusable;
+                _viewOverlay.ImportantForAccessibility = !isInAccessibleTree.HasValue ? Control.ImportantForAccessibility : (bool)isInAccessibleTree ? ImportantForAccessibility.Yes : ImportantForAccessibility.No;
+                _viewOverlay.ContentDescription = (string)Element.GetValue(AutomationProperties.NameProperty);
+            }
+
             Container.LayoutChange += ViewOnLayoutChange;
 
             if (EnableRipple)


### PR DESCRIPTION
Hi,

Sorry, It's my first PullRequest on Github.

We have seen that the touchEffect disable the accessibility on a Element on Android because the FrameLayout added on the view doesn't have the accessibility elements.

So we have added the accessibility element to the FrameLayout (only if they exist) (inspired by [https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/Xamarin.Forms.Platform.Android/Extensions/AccessibilityExtensions.cs](https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/Xamarin.Forms.Platform.Android/Extensions/AccessibilityExtensions.cs)). 